### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/chanlinesmasher/c936fdad-5e80-4988-9556-0a1bfb60d3cb/d5881dd9-171c-456e-a180-3b2f13086770/_apis/work/boardbadge/aba4d292-00e9-4d69-9758-7917744874cd)](https://dev.azure.com/chanlinesmasher/c936fdad-5e80-4988-9556-0a1bfb60d3cb/_boards/board/t/d5881dd9-171c-456e-a180-3b2f13086770/Microsoft.RequirementCategory)
 # 12-Beginner-Python-projects


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#41](https://dev.azure.com/chanlinesmasher/c936fdad-5e80-4988-9556-0a1bfb60d3cb/_workitems/edit/41). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.